### PR TITLE
laravel-page-speed-2.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,6 @@
 name: Tests
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,5 +48,5 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/contracts=^${{ matrix.laravel }}" --prefer-dist --no-interaction --no-update
+          composer require "illuminate/contracts=${{ matrix.laravel }}.*" --prefer-dist --no-interaction --no-update
           composer update --prefer-dist --no-interaction --no-progress

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,26 +11,14 @@ jobs:
         fail-fast: true
         matrix:
           php: ['8.0', 8.1, 8.2, 8.3]
-          laravel: [6, 7, 8, 9, 10, 11]
+          laravel: [8, 9, 10, 11]
           exclude:
             - php: '8.0'
               laravel: 10
             - php: '8.0'
               laravel: 11
             - php: 8.1
-              laravel: 6
-            - php: 8.1
-              laravel: 7
-            - php: 8.1
               laravel: 11
-            - php: 8.2
-              laravel: 6
-            - php: 8.2
-              laravel: 7
-            - php: 8.3
-              laravel: 6
-            - php: 8.3
-              laravel: 7
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,5 +48,5 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/contracts=${{ matrix.laravel }}.*" --prefer-dist --no-interaction --no-update
+          composer require "illuminate/contracts=^${{ matrix.laravel }}" --prefer-dist --no-interaction --no-update
           composer update --prefer-dist --no-interaction --no-progress

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,19 +9,29 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
-      matrix:
-        php: ['8.0', 8.1, 8.2, 8.3]
-        laravel: [9, 10, 11]
-        exclude:
-          - php: '8.0'
-            laravel: 10
-          - php: '8.0'
-            laravel: 11
-          - php: 8.1
-            laravel: 11
-          - php: 8.3
-            laravel: 9
+        fail-fast: true
+        matrix:
+          php: ['8.0', 8.1, 8.2, 8.3]
+          laravel: [6, 7, 8, 9, 10, 11]
+          exclude:
+            - php: '8.0'
+              laravel: 10
+            - php: '8.0'
+              laravel: 11
+            - php: 8.1
+              laravel: 6
+            - php: 8.1
+              laravel: 7
+            - php: 8.1
+              laravel: 11
+            - php: 8.2
+              laravel: 6
+            - php: 8.2
+              laravel: 7
+            - php: 8.3
+              laravel: 6
+            - php: 8.3
+              laravel: 7
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "php": "^7.4|^8.0",
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
         "codeat3/laravel-page-speed": "2.3",
         "symfony/process": "^5.0|^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -2,19 +2,13 @@
     "name": "codeat3/blade-icon-generation-helpers",
     "description": "codeat3's helper methods to use in blade-icon generation scripts",
     "license": "MIT",
-    "repositories": [
-        {
-            "type": "git",
-            "url": "git@github.com:codeat3/inlinestyle.git"
-        }
-    ],
     "require": {
         "php": "^7.4|^8.0",
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
         "codeat3/laravel-page-speed": "2.3",
         "symfony/process": "^5.0|^6.0|^7.0",
         "symfony/filesystem": "^5.0|^6.0|^7.0",
-        "codeat3/inlinestyle": "^2.0"
+        "codeat3/inlinestyle": "^2.1"
     },
     "require-dev": {
         "codeat3/phpcs-styles": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
-        "swapnilsarwe/laravel-page-speed": "dev-l11-support",
+        "codeat3/laravel-page-speed": "2.3",
         "symfony/process": "^5.0|^6.0|^7.0",
         "symfony/filesystem": "^5.0|^6.0|^7.0",
         "codeat3/inlinestyle": "^2.0"


### PR DESCRIPTION
using `"codeat3/laravel-page-speed": "2.3",` to add laravel 11 support.
updating dependencies.